### PR TITLE
Neuroscope refactoring

### DIFF
--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -324,8 +324,7 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         resfile_path: OptionalPathType = None,
         clufile_path: OptionalPathType = None,
         folder_path: OptionalPathType = None,
-        keep_mua_units: bool = True,
-        spkfile_path: OptionalPathType = None
+        keep_mua_units: bool = True
     ):
         assert HAVE_LXML, self.installation_mesg
         assert not (folder_path is None and resfile_path is None and clufile_path is None), \

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -84,15 +84,10 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
 
         BinDatRecordingExtractor.__init__(self, file_path, sampling_frequency=sampling_frequency,
                                           dtype=dtype, numchan=numchan_from_file)
-
-<<<<<<< HEAD
-        self._kwargs = dict(file_path=str(Path(file_path).absolute()))
-=======
         if gain is not None:
             self.set_channel_gains(channel_ids=self.get_channel_ids(), gains=gain)
 
         self._kwargs = dict(file_path=str(Path(file_path).absolute()), gain=gain)
->>>>>>> master
 
     @staticmethod
     def write_recording(

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -407,16 +407,14 @@ class NeuroscopeSortingExtractor(SortingExtractor):
                 resfile_path=None,
                 clufile_path=None,
                 folder_path=str(folder_path.absolute()),
-                keep_mua_units=keep_mua_units,
-                spkfile_path=None
+                keep_mua_units=keep_mua_units
             )
         else:
             self._kwargs = dict(
                 resfile_path=str(resfile_path.absolute()),
                 clufile_path=str(clufile_path.absolute()),
                 folder_path=None,
-                keep_mua_units=keep_mua_units,
-                spkfile_path=str(spkfile_path.absolute())
+                keep_mua_units=keep_mua_units
             )
 
     def get_unit_ids(self):

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -373,7 +373,8 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         res = np.loadtxt(resfile_path, dtype=np.int64, usecols=0, ndmin=1)
         clu = np.loadtxt(clufile_path, dtype=np.int64, usecols=0, ndmin=1)
 
-        if len(res) > 0:
+        n_spikes = len(res)
+        if n_spikes > 0:
             # Extract the number of unique IDs from the first line of the clufile then remove it from the list
             n_clu = clu[0]
             clu = np.delete(clu, 0)
@@ -398,10 +399,10 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         if spkfile_path is not None and Path(spkfile_path).is_file():
             n_bits = int(xml_root.find('acquisitionSystem').find('nBits').text)
             dtype = f"int{n_bits}"
-            nspikes = 1
-            nsamples = int(xml_root.find('neuroscope').find('spikes').find('nSamples').text)
-            nchannels = 1
-            wf = np.memmap(spkfile_path, dtype=dtype, shape=(nspikes, nsamples, nchannels))
+            n_samples = int(xml_root.find('neuroscope').find('spikes').find('nSamples').text)
+            wf = np.memmap(spkfile_path, dtype=dtype)
+            n_channels = int(wf.size / (n_spikes * n_samples))
+            wf = wf.reshape(n_spikes, n_samples, n_channels)
 
             for unit_id in self.get_unit_ids():
                 self.set_unit_spike_features(

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -372,7 +372,7 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         assert len(xml_files) == 1, "More than one .xml file found in the folder!"
         xml_filepath = xml_files[0]
 
-        xml_root = et.parse(str(xml_filepath.absolute())).getroot()
+        xml_root = et.parse(str(xml_filepath).getroot())
         self._sampling_frequency = float(xml_root.find('acquisitionSystem').find('samplingRate').text)
 
         with open(resfile_path) as f:

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -3,7 +3,7 @@ from spikeextractors.extractors.bindatrecordingextractor import BinDatRecordingE
 import numpy as np
 from pathlib import Path
 from spikeextractors.extraction_tools import check_valid_unit_id, get_sub_extractors_by_property
-from typing import Union
+from typing import Union, Optional
 import re
 import warnings
 
@@ -14,7 +14,8 @@ try:
 except ImportError:
     HAVE_LXML = False
 
-PathType = Union[str, Path, None]
+PathType = Union[str, Path]
+OptionalPathType = Optional[PathType]
 DtypeType = Union[str, np.dtype, None]
 
 
@@ -32,11 +33,11 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
         Path to the .dat file to be extracted
     """
 
-    extractor_name = 'NeuroscopeRecordingExtractor'
+    extractor_name = "NeuroscopeRecordingExtractor"
     installed = HAVE_LXML
     is_writable = True
-    mode = 'file'
-    installation_mesg = 'Please install lxml to use this extractor!'  # error message when not installed
+    mode = "file"
+    installation_mesg = "Please install lxml to use this extractor!"
 
     def __init__(self, file_path: PathType):
         assert HAVE_LXML, self.installation_mesg
@@ -49,12 +50,12 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
         file_path = Path(file_path)
         folder_path = file_path.parent
 
-        xml_files = [f for f in folder_path.iterdir() if f.is_file() if f.suffix == '.xml']
-        assert any(xml_files), 'No .xml file found in the folder_path.'
-        assert len(xml_files) == 1, 'More than one .xml file found in the folder_path.'
+        xml_files = [f for f in folder_path.iterdir() if f.is_file() if f.suffix == ".xml"]
+        assert any(xml_files), "No .xml file found in the folder_path."
+        assert len(xml_files) == 1, "More than one .xml file found in the folder_path."
         xml_filepath = xml_files[0]
 
-        xml_root = et.parse(str(xml_filepath.absolute())).getroot()
+        xml_root = et.parse(str(xml_filepath).getroot())
         n_bits = int(xml_root.find('acquisitionSystem').find('nBits').text)
         dtype = f"int{n_bits}"
         numchan_from_file = int(xml_root.find('acquisitionSystem').find('nChannels').text)
@@ -67,11 +68,15 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
         BinDatRecordingExtractor.__init__(self, file_path, sampling_frequency=sampling_frequency,
                                           dtype=dtype, numchan=numchan_from_file)
 
-        self._kwargs = {'file_path': str(Path(file_path).absolute())}
+        self._kwargs = dict(file_path=str(Path(file_path).absolute()))
 
     @staticmethod
-    def write_recording(recording: RecordingExtractor, save_path: PathType, dtype: DtypeType = None,
-                        **write_binary_kwargs):
+    def write_recording(
+        recording: RecordingExtractor,
+        save_path: PathType,
+        dtype: DtypeType = None,
+        **write_binary_kwargs
+    ):
         """
         Convert and save the recording extractor to Neuroscope format.
 
@@ -91,18 +96,18 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
         save_path = Path(save_path)
         save_path.mkdir(parents=True, exist_ok=True)
 
-        if save_path.suffix == '':
+        if save_path.suffix == "":
             recording_name = save_path.name
         else:
             recording_name = save_path.stem
         xml_name = recording_name
 
-        save_xml_filepath = save_path / (str(xml_name) + '.xml')
+        save_xml_filepath = save_path / f"{xml_name}.xml"
         recording_filepath = save_path / recording_name
 
         # create parameters file if none exists
         if save_xml_filepath.is_file():
-            raise FileExistsError(f'{save_xml_filepath} already exists!')
+            raise FileExistsError(f"{save_xml_filepath} already exists!")
 
         xml_root = et.Element('xml')
         et.SubElement(xml_root, 'acquisitionSystem')
@@ -114,25 +119,26 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
         int_loc = recording_dtype.find('int')
         recording_n_bits = recording_dtype[(int_loc + 3):(int_loc + 5)]
 
-        if dtype is None:  # user did not specify data type
-            if int_loc != -1 and recording_n_bits in ['16', '32']:
+        valid_dtype = ["16", "32"]
+        if dtype is None:
+            if int_loc != -1 and recording_n_bits in valid_dtype:
                 n_bits = recording_n_bits
             else:
-                print('Warning: Recording data type must be int16 or int32! Defaulting to int32.')
-                n_bits = '32'
-            dtype = 'int' + n_bits  # update dtype in pass to BinDatRecordingExtractor.write_recording
+                print("Warning: Recording data type must be int16 or int32! Defaulting to int32.")
+                n_bits = "32"
+            dtype = f"int{n_bits}"  # update dtype in pass to BinDatRecordingExtractor.write_recording
         else:
             dtype = str(dtype)  # if user passed numpy data type
             int_loc = dtype.find('int')
-            assert int_loc != -1, 'Data type must be int16 or int32! Non-integer received.'
+            assert int_loc != -1, "Data type must be int16 or int32! Non-integer received."
             n_bits = dtype[(int_loc + 3):(int_loc + 5)]
-            assert n_bits in ['16', '32'], 'Data type must be int16 or int32!'
+            assert n_bits in valid_dtype, "Data type must be int16 or int32!"
 
         xml_root.find('acquisitionSystem').find('nBits').text = n_bits
         xml_root.find('acquisitionSystem').find('nChannels').text = str(recording.get_num_channels())
         xml_root.find('acquisitionSystem').find('samplingRate').text = str(recording.get_sampling_frequency())
 
-        et.ElementTree(xml_root).write(str(save_xml_filepath.absolute()), pretty_print=True)
+        et.ElementTree(xml_root).write(str(save_xml_filepath), pretty_print=True)
 
         recording.write_to_binary_dat_format(recording_filepath, dtype=dtype, **write_binary_kwargs)
 
@@ -170,8 +176,12 @@ class NeuroscopeMultiRecordingTimeExtractor(MultiRecordingTimeExtractor):
         self._kwargs = {'folder_path': str(folder_path.absolute())}
 
     @staticmethod
-    def write_recording(recording: Union[MultiRecordingTimeExtractor, RecordingExtractor],
-                        save_path: PathType, dtype: DtypeType = None, **write_binary_kwargs):
+    def write_recording(
+        recording: Union[MultiRecordingTimeExtractor, RecordingExtractor],
+        save_path: PathType,
+        dtype: DtypeType = None,
+        **write_binary_kwargs
+    ):
         """
         Convert and save the recording extractor to Neuroscope format.
 
@@ -279,63 +289,66 @@ class NeuroscopeSortingExtractor(SortingExtractor):
 
     Parameters
     ----------
-    resfile_path : str
+    resfile_path : PathType
         Optional. Path to a particular .res text file.
-    clufile_path : str
+    clufile_path : PathType
         Optional. Path to a particular .clu text file.
-    folder_path : str
+    folder_path : PathType
         Optional. Path to the collection of .res and .clu text files. Will auto-detect format.
     keep_mua_units : bool
         Optional. Whether or not to return sorted spikes from multi-unit activity. Defaults to True.
+    spkfile_path : PathType
+        Optional. Path to a particular .spk binary file containing waveform snippets added to the extractor as features.
     """
 
-    extractor_name = 'NeuroscopeSortingExtractor'
-    installed = HAVE_LXML  # check at class level if installed or not
+    extractor_name = "NeuroscopeSortingExtractor"
+    installed = HAVE_LXML
     is_writable = True
-    mode = 'custom'
-    installation_mesg = 'Please install lxml to use this extractor!'  # error message when not installed
+    mode = "custom"
+    installation_mesg = "Please install lxml to use this extractor!"
 
-    def __init__(self, resfile_path: PathType = None, clufile_path: PathType = None, folder_path: PathType = None,
-                 keep_mua_units: bool = True):
+    def __init__(
+        self,
+        resfile_path: OptionalPathType = None,
+        clufile_path: OptionalPathType = None,
+        folder_path: OptionalPathType = None,
+        keep_mua_units: bool = True,
+        spkfile_path: OptionalPathType = None
+    ):
         assert HAVE_LXML, self.installation_mesg
-
-        # None of the location arguments were passed
         assert not (folder_path is None and resfile_path is None and clufile_path is None), \
-            'Either pass a single folder_path location, or a pair of resfile_path and clufile_path. None received.'
+            "Either pass a single folder_path location, or a pair of resfile_path and clufile_path! None received."
 
-        # At least one file_path passed
         if resfile_path is not None:
-            assert clufile_path is not None, 'If passing resfile_path or clufile_path, both are required.'
+            assert clufile_path is not None, "If passing resfile_path or clufile_path, both are required!"
             resfile_path = Path(resfile_path)
             clufile_path = Path(clufile_path)
             assert resfile_path.is_file() and clufile_path.is_file(), \
-                'The resfile_path ({}) and clufile_path ({}) must be .res and .clu files!'.format(resfile_path,
-                                                                                                  clufile_path)
+                f"The resfile_path ({resfile_path}) and clufile_path ({clufile_path}) must be .res and .clu files!"
 
-            assert folder_path is None, 'Pass either a single folder_path location, ' \
-                                        'or a pair of resfile_path and clufile_path. All received.'
+            assert folder_path is None, "Pass either a single folder_path location, " \
+                                        "or a pair of resfile_path and clufile_path! All received."
             folder_path_passed = False
             folder_path = resfile_path.parent
         else:
-            assert folder_path is not None, 'Either pass resfile_path and clufile_path, or folder_path'
+            assert folder_path is not None, "Either pass resfile_path and clufile_path, or folder_path!"
             folder_path = Path(folder_path)
-            assert folder_path.is_dir(), 'The folder_path must be a directory!'
+            assert folder_path.is_dir(), "The folder_path must be a directory!"
 
-            res_files = [f for f in folder_path.iterdir() if f.is_file()
-                         and '.res' in f.suffixes 
-                         and '.temp' not in f.suffixes
-                         and not f.name.endswith('~')
-                         and len(f.suffixes) == 1]
-            clu_files = [f for f in folder_path.iterdir() if f.is_file()
-                         and '.clu' in f.suffixes 
-                         and not f.name.endswith('~')
-                         and len(f.suffixes) == 1]
+            res_files = [
+                f for f in folder_path.iterdir() if f.is_file() and ".res" in f.suffixes and ".temp" not in f.suffixes
+                and not f.name.endswith("~") and len(f.suffixes) == 1
+            ]
+            clu_files = [
+                f for f in folder_path.iterdir() if f.is_file() and ".clu" in f.suffixes and not f.name.endswith("~")
+                and len(f.suffixes) == 1
+            ]
 
             assert len(res_files) > 0 or len(clu_files) > 0, \
-                'No .res or .clu files found in the folder_path.'
+                "No .res or .clu files found in the folder_path!"
             assert len(res_files) == 1 and len(clu_files) == 1, \
-                'NeuroscopeSortingExtractor expects a single pair of .res and .clu files in the folder_path. ' \
-                'For multiple .res and .clu files, use the NeuroscopeMultiSortingExtractor instead.'
+                "NeuroscopeSortingExtractor expects a single pair of .res and .clu files in the folder_path. " \
+                "For multiple .res and .clu files, use the NeuroscopeMultiSortingExtractor instead."
 
             folder_path_passed = True  # flag for setting kwargs for proper dumping
             resfile_path = res_files[0]
@@ -346,23 +359,22 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         res_sorting_name = resfile_path.name[:resfile_path.name.find('.res')]
         clu_sorting_name = clufile_path.name[:clufile_path.name.find('.clu')]
 
-        assert res_sorting_name == clu_sorting_name, f'The .res and .clu files do not share the same name! ' \
-                                                     f'{res_sorting_name}  -- {clu_sorting_name}'
+        assert res_sorting_name == clu_sorting_name, "The .res and .clu files do not share the same name! " \
+                                                     f"{res_sorting_name}  -- {clu_sorting_name}"
 
-        xml_files = [f for f in folder_path.iterdir() if f.is_file() if f.suffix == '.xml']
-        assert len(xml_files) > 0, 'No .xml file found in the folder.'
-        assert len(xml_files) == 1, 'More than one .xml file found in the folder.'
+        xml_files = [f for f in folder_path.iterdir() if f.is_file() if f.suffix == ".xml"]
+        assert len(xml_files) > 0, "No .xml file found in the folder!"
+        assert len(xml_files) == 1, "More than one .xml file found in the folder!"
         xml_filepath = xml_files[0]
 
         xml_root = et.parse(str(xml_filepath.absolute())).getroot()
-        self._sampling_frequency = float(xml_root.find('acquisitionSystem').find(
-            'samplingRate').text)  # careful not to confuse it with the lfpsamplingrate
+        self._sampling_frequency = float(xml_root.find('acquisitionSystem').find('samplingRate').text)
 
         res = np.loadtxt(resfile_path, dtype=np.int64, usecols=0, ndmin=1)
         clu = np.loadtxt(clufile_path, dtype=np.int64, usecols=0, ndmin=1)
 
         if len(res) > 0:
-            # Extract the number of clusters read as the first line of the clufile then remove it from the clu list
+            # Extract the number of unique IDs from the first line of the clufile then remove it from the list
             n_clu = clu[0]
             clu = np.delete(clu, 0)
             unique_ids = np.unique(clu)
@@ -371,33 +383,49 @@ class NeuroscopeSortingExtractor(SortingExtractor):
             if 1 not in unique_ids:  # missing mua IDs
                 n_clu += 1
 
-            # Initialize spike trains and extract times from .res and appropriate clusters from .clu based on
-            # user input for ignoring multi-unit activity
             self._spiketrains = []
-            if keep_mua_units:  # default
+            if keep_mua_units:
                 n_clu -= 1
-                self._unit_ids = [x + 1 for x in range(n_clu)]  # generates list from 1,...,clu[0]-1
+                self._unit_ids = [x + 1 for x in range(n_clu)]  # from 1,...,clu[0]-1
                 for s_id in self._unit_ids:
                     self._spiketrains.append(res[(clu == s_id).nonzero()])
             else:
-                # Ignoring IDs of 0 until get_unsorted_spike_train is implemented into base
-                # Also ignoring IDs of 1 since user called keep_mua_units=False
                 n_clu -= 2
-                self._unit_ids = [x + 1 for x in range(n_clu)]  # generates list from 1,...,clu[0]-2
+                self._unit_ids = [x + 1 for x in range(n_clu)]  # from 1,...,clu[0]-2
                 for s_id in self._unit_ids:
-                    self._spiketrains.append(
-                        res[(clu == s_id + 1).nonzero()])  # only reading cluster IDs 2,...,clu[0]-1
+                    self._spiketrains.append(res[(clu == s_id + 1).nonzero()])  # from 2,...,clu[0]-1
+
+        if spkfile_path is not None and Path(spkfile_path).is_file():
+            n_bits = int(xml_root.find('acquisitionSystem').find('nBits').text)
+            dtype = f"int{n_bits}"
+            nspikes = 1
+            nsamples = int(xml_root.find('neuroscope').find('spikes').find('nSamples').text)
+            nchannels = 1
+            wf = np.memmap(spkfile_path, dtype=dtype, shape=(nspikes, nsamples, nchannels))
+
+            for unit_id in self.get_unit_ids():
+                self.set_unit_spike_features(
+                    unit_id=unit_id,
+                    feature_name='waveforms',
+                    value=wf[clu == unit_id + 1 - int(keep_mua_units), :, :]
+                )
 
         if folder_path_passed:
-            self._kwargs = {'resfile_path': None,
-                            'clufile_path': None,
-                            'folder_path': str(folder_path.absolute()),
-                            'keep_mua_units': keep_mua_units}
+            self._kwargs = dict(
+                resfile_path=None,
+                clufile_path=None,
+                folder_path=str(folder_path.absolute()),
+                keep_mua_units=keep_mua_units,
+                spkfile_path=None
+            )
         else:
-            self._kwargs = {'resfile_path': str(resfile_path.absolute()),
-                            'clufile_path': str(clufile_path.absolute()),
-                            'folder_path': None,
-                            'keep_mua_units': keep_mua_units}
+            self._kwargs = dict(
+                resfile_path=str(resfile_path.absolute()),
+                clufile_path=str(clufile_path.absolute()),
+                folder_path=None,
+                keep_mua_units=keep_mua_units,
+                spkfile_path=str(spkfile_path.absolute())
+            )
 
     def get_unit_ids(self):
         return list(self._unit_ids)
@@ -495,62 +523,65 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
         final integer of all the .res.%i and .clu.%i pairs.
     """
 
-    extractor_name = 'NeuroscopeMultiSortingExtractor'
-    installed = HAVE_LXML  # check at class level if installed or not
+    extractor_name = "NeuroscopeMultiSortingExtractor"
+    installed = HAVE_LXML
     is_writable = True
-    mode = 'folder'
-    installation_mesg = 'Please install lxml to use this extractor!'  # error message when not installed
+    mode = "folder"
+    installation_mesg = "Please install lxml to use this extractor!"
 
-    def __init__(self, folder_path: PathType, keep_mua_units: bool = True, exclude_shanks: Union[list, None] = None):
+    def __init__(
+        self,
+        folder_path: PathType,
+        keep_mua_units: bool = True,
+        exclude_shanks: Union[list, None] = None
+    ):
         assert HAVE_LXML, self.installation_mesg
 
         folder_path = Path(folder_path)
 
         if exclude_shanks is not None:  # dumping checks do not like having an empty list as default
             assert all([isinstance(x, (int, np.integer)) and x >= 0 for x in
-                        exclude_shanks]), 'Optional argument "exclude_shanks" must contain positive integers only!'
+                        exclude_shanks]), "Optional argument 'exclude_shanks' must contain positive integers only!"
             exclude_shanks_passed = True
         else:
             exclude_shanks = []
             exclude_shanks_passed = False
-        xml_files = [f for f in folder_path.iterdir() if f.is_file if f.suffix == '.xml']
-        assert len(xml_files) > 0, 'No .xml file found in the folder.'
-        assert len(xml_files) == 1, 'More than one .xml file found in the folder.'
+        xml_files = [f for f in folder_path.iterdir() if f.is_file if f.suffix == ".xml"]
+        assert len(xml_files) > 0, "No .xml file found in the folder!"
+        assert len(xml_files) == 1, "More than one .xml file found in the folder!"
         xml_filepath = xml_files[0]
 
         xml_root = et.parse(str(xml_filepath.absolute())).getroot()
-        self._sampling_frequency = float(xml_root.find('acquisitionSystem').find(
-            'samplingRate').text)  # careful not to confuse it with the lfpsamplingrate
+        self._sampling_frequency = float(xml_root.find('acquisitionSystem').find('samplingRate').text)
 
         res_files = [f for f in folder_path.iterdir() if f.is_file()
-                     and '.res' in f.suffixes 
-                     and re.search(r'\d+$', f.name) is not None
+                     and ".res" in f.suffixes
+                     and re.search(r"\d+$", f.name) is not None
                      and len(f.suffixes) == 2]
         clu_files = [f for f in folder_path.iterdir() if f.is_file()
-                     and '.clu' in f.suffixes 
-                     and re.search(r'\d+$', f.name) is not None
+                     and ".clu" in f.suffixes
+                     and re.search(r"\d+$", f.name) is not None
                      and len(f.suffixes) == 2]
 
-        assert len(res_files) > 0 or len(clu_files) > 0, \
-            'No .res or .clu files found in the folder_path.'
+        assert len(res_files) > 0 or len(clu_files) > 0, "No .res or .clu files found in the folder_path!"
         assert len(res_files) == len(clu_files)
 
         res_ids = [int(x.suffix[1:]) for x in res_files]
         clu_ids = [int(x.suffix[1:]) for x in clu_files]
-        assert sorted(res_ids) == sorted(clu_ids), 'Unmatched .clu.%i and .res.%i files detected!'
+        assert sorted(res_ids) == sorted(clu_ids), "Unmatched .clu.%i and .res.%i files detected!"
         if any([x not in res_ids for x in exclude_shanks]):
-            print('Warning: Detected indices in exclude_shanks that are not in the directory. These will be ignored.')
+            warnings.warn("Detected indices in exclude_shanks that are not in the directory! These will be ignored.")
 
         resfile_names = [x.name[:x.name.find('.res')] for x in res_files]
         clufile_names = [x.name[:x.name.find('.clu')] for x in clu_files]
         assert np.all(r == c for (r, c) in zip(resfile_names, clufile_names)), \
-            'Some of the .res.%i and .clu.%i files do not share the same name!'
+            "Some of the .res.%i and .clu.%i files do not share the same name!"
         sorting_name = resfile_names[0]
 
         all_shanks_list_se = []
         for shank_id in list(set(res_ids) - set(exclude_shanks)):
-            resfile_path = folder_path / f'{sorting_name}.res.{shank_id}'
-            clufile_path = folder_path / f'{sorting_name}.clu.{shank_id}'
+            resfile_path = folder_path / f"{sorting_name}.res.{shank_id}"
+            clufile_path = folder_path / f"{sorting_name}.clu.{shank_id}"
 
             all_shanks_list_se.append(NeuroscopeSortingExtractor(resfile_path=resfile_path,
                                                                  clufile_path=clufile_path,
@@ -559,13 +590,17 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
         MultiSortingExtractor.__init__(self, sortings=all_shanks_list_se)
 
         if exclude_shanks_passed:
-            self._kwargs = {'folder_path': str(folder_path.absolute()),
-                            'keep_mua_units': keep_mua_units,
-                            'exclude_shanks': exclude_shanks}
+            self._kwargs = dict(
+                folder_path=str(folder_path.absolute()),
+                keep_mua_units=keep_mua_units,
+                exclude_shanks=exclude_shanks
+            )
         else:
-            self._kwargs = {'folder_path': str(folder_path.absolute()),
-                            'keep_mua_units': keep_mua_units,
-                            'exclude_shanks': None}
+            self._kwargs = dict(
+                folder_path=str(folder_path.absolute()),
+                keep_mua_units=keep_mua_units,
+                exclude_shanks=None
+            )
 
     @staticmethod
     def write_sorting(sorting: Union[MultiSortingExtractor, SortingExtractor], save_path: PathType):
@@ -577,11 +612,11 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
         xml_name = sorting_name
         save_xml_filepath = save_path / (str(xml_name) + '.xml')
 
-        assert not save_path.is_file(), "'save_path' should be a folder"
+        assert not save_path.is_file(), "Argument 'save_path' should be a folder!"
         save_path.mkdir(parents=True, exist_ok=True)
 
         if save_xml_filepath.is_file():
-            raise FileExistsError(f'{save_xml_filepath} already exists!')
+            raise FileExistsError(f"{save_xml_filepath} already exists!")
 
         xml_root = et.Element('xml')
         et.SubElement(xml_root, 'acquisitionSystem')
@@ -593,14 +628,14 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
             counter = 1
             for sort in sorting.sortings:
                 # Create and save .res.%i and .clu.%i files from the current sorting object
-                save_res = save_path / f'{sorting_name}.res.{counter}'
-                save_clu = save_path / f'{sorting_name}.clu.{counter}'
+                save_res = save_path / f"{sorting_name}.res.{counter}"
+                save_clu = save_path / f"{sorting_name}.clu.{counter}"
                 counter += 1
 
                 res, clu = _extract_res_clu_arrays(sort)
 
-                np.savetxt(save_res, res, fmt='%i')
-                np.savetxt(save_clu, clu, fmt='%i')
+                np.savetxt(save_res, res, fmt="%i")
+                np.savetxt(save_clu, clu, fmt="%i")
 
         elif isinstance(sorting, SortingExtractor):
             # assert units have group property
@@ -609,13 +644,13 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
 
             for (sort, group) in zip(sortings, groups):
                 # Create and save .res.%i and .clu.%i files from the current sorting object
-                save_res = save_path / f'{sorting_name}.res.{group}'
-                save_clu = save_path / f'{sorting_name}.clu.{group}'
+                save_res = save_path / f"{sorting_name}.res.{group}"
+                save_clu = save_path / f"{sorting_name}.clu.{group}"
 
                 res, clu = _extract_res_clu_arrays(sort)
 
-                np.savetxt(save_res, res, fmt='%i')
-                np.savetxt(save_clu, clu, fmt='%i')
+                np.savetxt(save_res, res, fmt="%i")
+                np.savetxt(save_clu, clu, fmt="%i")
 
 
 def _extract_res_clu_arrays(sorting):

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -375,8 +375,10 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         xml_root = et.parse(str(xml_filepath.absolute())).getroot()
         self._sampling_frequency = float(xml_root.find('acquisitionSystem').find('samplingRate').text)
 
-        res = np.loadtxt(resfile_path, dtype=np.int64, usecols=0, ndmin=1)
-        clu = np.loadtxt(clufile_path, dtype=np.int64, usecols=0, ndmin=1)
+        with open(resfile_path) as f:
+            res = np.array([int(line) for line in f], np.int64)
+        with open(clufile_path) as f:
+            clu = np.array([int(line) for line in f], np.int64)
 
         n_spikes = len(res)
         if n_spikes > 0:

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -69,7 +69,7 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
         assert len(xml_files) == 1, "More than one .xml file found in the folder_path."
         xml_filepath = xml_files[0]
 
-        xml_root = et.parse(str(xml_filepath).getroot())
+        xml_root = et.parse(str(xml_filepath)).getroot()
         n_bits = int(xml_root.find('acquisitionSystem').find('nBits').text)
         dtype = f"int{n_bits}"
         numchan_from_file = int(xml_root.find('acquisitionSystem').find('nChannels').text)
@@ -372,7 +372,7 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         assert len(xml_files) == 1, "More than one .xml file found in the folder!"
         xml_filepath = xml_files[0]
 
-        xml_root = et.parse(str(xml_filepath).getroot())
+        xml_root = et.parse(str(xml_filepath)).getroot()
         self._sampling_frequency = float(xml_root.find('acquisitionSystem').find('samplingRate').text)
 
         with open(resfile_path) as f:
@@ -542,7 +542,7 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
         assert len(xml_files) == 1, "More than one .xml file found in the folder!"
         xml_filepath = xml_files[0]
 
-        xml_root = et.parse(str(xml_filepath).getroot())
+        xml_root = et.parse(str(xml_filepath)).getroot()
         self._sampling_frequency = float(xml_root.find('acquisitionSystem').find('samplingRate').text)
 
         res_files = get_shank_files(folder_path=folder_path, suffix=".res")

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -297,8 +297,6 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         Optional. Path to the collection of .res and .clu text files. Will auto-detect format.
     keep_mua_units : bool
         Optional. Whether or not to return sorted spikes from multi-unit activity. Defaults to True.
-    spkfile_path : PathType
-        Optional. Path to a particular .spk binary file containing waveform snippets added to the extractor as features.
     """
 
     extractor_name = "NeuroscopeSortingExtractor"
@@ -395,21 +393,6 @@ class NeuroscopeSortingExtractor(SortingExtractor):
                 self._unit_ids = [x + 1 for x in range(n_clu)]  # from 1,...,clu[0]-2
                 for s_id in self._unit_ids:
                     self._spiketrains.append(res[(clu == s_id + 1).nonzero()])  # from 2,...,clu[0]-1
-
-        if spkfile_path is not None and Path(spkfile_path).is_file():
-            n_bits = int(xml_root.find('acquisitionSystem').find('nBits').text)
-            dtype = f"int{n_bits}"
-            n_samples = int(xml_root.find('neuroscope').find('spikes').find('nSamples').text)
-            wf = np.memmap(spkfile_path, dtype=dtype)
-            n_channels = int(wf.size / (n_spikes * n_samples))
-            wf = wf.reshape(n_spikes, n_samples, n_channels)
-
-            for unit_id in self.get_unit_ids():
-                self.set_unit_spike_features(
-                    unit_id=unit_id,
-                    feature_name='waveforms',
-                    value=wf[clu == unit_id + 1 - int(keep_mua_units), :, :]
-                )
 
         if folder_path_passed:
             self._kwargs = dict(

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -523,7 +523,7 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
         self,
         folder_path: PathType,
         keep_mua_units: bool = True,
-        exclude_shanks: Union[list, None] = None
+        exclude_shanks: Optional[list] = None
     ):
         assert HAVE_LXML, self.installation_mesg
 

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -1232,8 +1232,6 @@ class NwbSortingExtractor(se.SortingExtractor):
                     flatten_vals = [item for sublist in values for item in sublist]
                     nspks_list = [sp for sp in nspikes.values()]
                     spikes_index = np.cumsum(nspks_list).astype('int64')
-                    print(nwbfile.units)
-                    print(unit_ids)
                     set_dynamic_table_property(
                         dynamic_table=nwbfile.units,
                         row_ids=unit_ids,

--- a/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
@@ -90,7 +90,7 @@ class SpikeGLXRecordingExtractor(RecordingExtractor):
             gains = GainCorrectNI(self._timeseries, self._channels, meta)
 
         # set gains - convert from int16 to uVolt
-        self.set_channel_gains(self._channels, gains*1e6)
+        self.set_channel_gains(gains=gains*1e6, channel_ids=self._channels)
         self._kwargs = {'file_path': str(Path(file_path).absolute()), 'dtype': dtype}
 
     def get_channel_ids(self):

--- a/spikeextractors/sortingextractor.py
+++ b/spikeextractors/sortingextractor.py
@@ -119,7 +119,7 @@ class SortingExtractor(ABC, BaseExtractor):
             formats as specified by the user.
         indexes: array_like
             The indices of the specified spikes (if the number of spike features
-            is less than the length of the uint's spike train). If None, it is
+            is less than the length of the unit's spike train). If None, it is
             assumed that value has the same length as the spike train.
         '''
         if isinstance(unit_id, (int, np.integer)):


### PR DESCRIPTION
@alejoe91 Standardized styling and format for the four extractors, updated docstrings, removed unneeded absolute paths. Very minor changes overall, but makes it easier to view the changelogs of the PR's inheriting from this.

Biggest computational change is the removal of `np.loadtxt`, [which is quite slow](https://stackoverflow.com/questions/52232559/numpy-loadtxt-is-way-slower-than-open-readlines), and instead just read the lines directly.