### PR TITLE
added nwb waveform writing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 
 install:
-- pip install h5py==2.10.0 mountainlab_pytools pynwb==1.3.3 pyopenephys kbucket MEArec>=1.5.0 shybrid exdir ruamel.yaml nixio neo>=0.8 hdf5storage bs4 lxml
+- pip install pandas==1.1.5 h5py==2.10.0 mountainlab_pytools pynwb==1.3.3 pyopenephys kbucket MEArec>=1.5.0 shybrid exdir ruamel.yaml nixio neo>=0.8 hdf5storage bs4 lxml
 - pip install .
 - pip install pytest==3.6
 script: pytest

--- a/spikeextractors/baseextractor.py
+++ b/spikeextractors/baseextractor.py
@@ -23,7 +23,7 @@ class BaseExtractor:
         self._tmp_folder = None
         self._key_properties = {}
         self._properties = {}
-        self._object_properties = {}
+        self._annotations = {}
         self._memmap_files = []
         self._features = {}
         self._epochs = {}
@@ -88,11 +88,11 @@ class BaseExtractor:
 
         if self.is_dumpable:
             dump_dict = {'class': class_name, 'module': module, 'kwargs': self._kwargs,
-                         'key_properties': self._key_properties, 'object_properties': self._object_properties,
+                         'key_properties': self._key_properties, 'annotations': self._annotations,
                          'version': version, 'dumpable': True}
         else:
             dump_dict = {'class': class_name, 'module': module, 'kwargs': {}, 'key_properties': self._key_properties,
-                         'object_properties': self._object_properties, 'version': imported_module.__version__,
+                         'annotations': self._annotations, 'version': imported_module.__version__,
                          'dumpable': False}
         return dump_dict
 
@@ -273,66 +273,66 @@ class BaseExtractor:
                 arr = np.zeros(shape, dtype=dtype)
         return arr
 
-    def set_object_property(self, property_name, value, overwrite=False):
-        '''This function adds an entry to the object property dictionary.
+    def set_annotation(self, annotation_name, value, overwrite=False):
+        '''This function adds an entry to the annotations dictionary.
 
         Parameters
         ----------
-        property_name: str
-            A property stored by the Extractor (location, etc.)
+        annotation_name: str
+            An annotation stored by the Extractor
         value:
             The data associated with the given property name. Could be many
             formats as specified by the user
         overwrite: bool
-            If True and the object property already exists, it is overwritten
+            If True and the annotation already exists, it is overwritten
         '''
-        if property_name not in self._object_properties.keys():
-            self._object_properties[property_name] = value
+        if annotation_name not in self._annotations.keys():
+            self._annotations[annotation_name] = value
         else:
             if overwrite:
-                self._object_properties[property_name] = value
+                self._annotations[annotation_name] = value
             else:
-                print(f"{property_name} is already an object property. Use 'overwrite=True' to overwrite it")
+                print(f"{annotation_name} is already an annotation. Use 'overwrite=True' to overwrite it")
 
-    def get_object_property(self, property_name):
-        '''This function returns the data stored under the object property name .
+    def get_annotation(self, annotation_name):
+        '''This function returns the data stored under the annotation name .
 
         Parameters
         ----------
-        property_name: str
+        annotation_name: str
             A property stored by the Extractor
 
         Returns
         ----------
-        property_data
+        annotation_data
             The data associated with the given property name. Could be many
             formats as specified by the user
         '''
-        if property_name not in self._object_properties.keys():
-            print(f"{property_name} is not an object property")
+        if annotation_name not in self._annotations.keys():
+            print(f"{annotation_name} is not an annotation")
             return None
         else:
-            return deepcopy(self._object_properties[property_name])
+            return deepcopy(self._annotations[annotation_name])
 
-    def get_object_property_names(self):
-        '''This function returns a list of stored object property names
+    def get_annotation_names(self):
+        '''This function returns a list of stored annotation names
 
         Returns
         ----------
         property_names: list
-            List of stored object property names
+            List of stored annotation names
         '''
-        return list(self._object_properties.keys())
+        return list(self._annotations.keys())
 
-    def copy_object_properties(self, extractor):
+    def copy_annotations(self, extractor):
         '''Copy object properties from another extractor to the current extractor.
 
         Parameters
         ----------
         extractor: Extractor
-            The extractor from which the object properties will be copied
+            The extractor from which the annotations will be copied
         '''
-        self._object_properties = deepcopy(extractor._object_properties)
+        self._annotations = deepcopy(extractor._annotations)
 
     def _cast_start_end_frame(self, start_frame, end_frame):
         from .extraction_tools import cast_start_end_frame
@@ -458,8 +458,8 @@ def _load_extractor_from_dict(dic):
     if 'key_properties' in dic.keys():
         extractor._key_properties = dic['key_properties']
 
-    if 'object_properties' in dic.keys():
-        extractor._object_properties = dic['object_properties']
+    if 'annotations' in dic.keys():
+        extractor._annotations = dic['annotations']
 
     return extractor
 

--- a/spikeextractors/baseextractor.py
+++ b/spikeextractors/baseextractor.py
@@ -273,12 +273,12 @@ class BaseExtractor:
                 arr = np.zeros(shape, dtype=dtype)
         return arr
 
-    def set_annotation(self, annotation_name, value, overwrite=False):
+    def annotate(self, annotation_key, value, overwrite=False):
         '''This function adds an entry to the annotations dictionary.
 
         Parameters
         ----------
-        annotation_name: str
+        annotation_key: str
             An annotation stored by the Extractor
         value:
             The data associated with the given property name. Could be many
@@ -286,13 +286,13 @@ class BaseExtractor:
         overwrite: bool
             If True and the annotation already exists, it is overwritten
         '''
-        if annotation_name not in self._annotations.keys():
-            self._annotations[annotation_name] = value
+        if annotation_key not in self._annotations.keys():
+            self._annotations[annotation_key] = value
         else:
             if overwrite:
-                self._annotations[annotation_name] = value
+                self._annotations[annotation_key] = value
             else:
-                print(f"{annotation_name} is already an annotation. Use 'overwrite=True' to overwrite it")
+                print(f"{annotation_key} is already an annotation key. Use 'overwrite=True' to overwrite it")
 
     def get_annotation(self, annotation_name):
         '''This function returns the data stored under the annotation name .
@@ -314,13 +314,13 @@ class BaseExtractor:
         else:
             return deepcopy(self._annotations[annotation_name])
 
-    def get_annotation_names(self):
-        '''This function returns a list of stored annotation names
+    def get_annotation_keys(self):
+        '''This function returns a list of stored annotation keys
 
         Returns
         ----------
         property_names: list
-            List of stored annotation names
+            List of stored annotation keys
         '''
         return list(self._annotations.keys())
 

--- a/spikeextractors/extractors/hdsortsortingextractor/hdsortsortingextractor.py
+++ b/spikeextractors/extractors/hdsortsortingextractor/hdsortsortingextractor.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import Union
 import numpy as np
+import sys
+import os
 
 from spikeextractors.extractors.matsortingextractor.matsortingextractor import MATSortingExtractor, HAVE_MAT
 from spikeextractors.extraction_tools import check_valid_unit_id
@@ -109,7 +111,10 @@ class HDSortSortingExtractor(MATSortingExtractor):
         return self._unit_ids.tolist()
 
     @staticmethod
-    def write_sorting(sorting, save_path, locations=None, noise_std_by_channel=None, start_frame=0):
+    def write_sorting(sorting, save_path, locations=None, noise_std_by_channel=None, start_frame=0,
+                      convert_cell_to_struct=True):
+        source_dir = Path(__file__).parent
+
         # First, find out how many channels there are
         if locations is not None:
             # write_locations must be a 2D numpy array with n_channels in first dim., (x,y) in second dim.
@@ -154,7 +159,7 @@ class HDSortSortingExtractor(MATSortingExtractor):
                 unit["detectionChannel"] = np.ones(num_spikes, np.double)
 
             if "template" in sorting.get_unit_property_names(uid):
-                unit["footprint"] = sorting.get_unit_property(uid, "template")
+                unit["footprint"] = sorting.get_unit_property(uid, "template").T
             else:
                 # If this unit does not have a footprint, create an empty one:
                 unit["footprint"] = np.zeros((3, n_channels), np.double)
@@ -178,13 +183,43 @@ class HDSortSortingExtractor(MATSortingExtractor):
         if noise_std_by_channel is None:
             noise_std_by_channel = np.ones((1, n_channels))
 
-        dict_to_save = {'Units': units,
+        dict_to_save = {'Units': np.array(units),
                         'MultiElectrode': multi_electrode,
                         'noiseStd': noise_std_by_channel,
                         "samplingRate": sorting._sampling_frequency}
 
         # Save Units and MultiElectrode to .mat file:
         MATSortingExtractor.write_dict_to_mat(save_path, dict_to_save, version='7.3')
+
+        if convert_cell_to_struct:
+            # read the template txt files
+            with (source_dir / 'convert_cellarray_to_structarray.m').open('r') as f:
+                convert_cellarray_to_structarray = f.read()
+            convert_cellarray_to_structarray = f"fileName='{str(Path(save_path).absolute())}';\n" \
+                                               f"{convert_cellarray_to_structarray}"
+            convert_script = Path(save_path).parent / "convert_cellarray_to_structarray.m"
+
+            with convert_script.open('w') as f:
+                f.write(convert_cellarray_to_structarray)
+
+            if 'win' in sys.platform and sys.platform != 'darwin':
+                matlab_cmd = '''
+                             #!/bin/bash
+                             cd {tmpdir}
+                             matlab -nosplash -wait -log -r convert_cellarray_to_structarray
+                             '''.format(tmpdir={str(convert_script.parent)})
+            else:
+                matlab_cmd = '''
+                             #!/bin/bash
+                             cd {tmpdir}
+                             matlab -nosplash -nodisplay -log -r convert_cellarray_to_structarray
+                             '''.format(tmpdir={str(convert_script.parent)})
+
+            try:
+                os.system(matlab_cmd)
+            except:
+                print("Failed to convert cell array to struct array")
+            convert_script.unlink()
 
 
 # For .mat v7.3: Function to extract all fields of a struct-array:

--- a/spikeextractors/extractors/neoextractors/blackrockextractor.py
+++ b/spikeextractors/extractors/neoextractors/blackrockextractor.py
@@ -1,10 +1,15 @@
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from pathlib import Path
+from typing import Union, Optional
 
 try:
     import neo
     HAVE_NEO = True
 except ImportError:
     HAVE_NEO = False
+
+
+PathType = Union[str, Path]
 
 
 class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
@@ -25,6 +30,9 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
     mode = 'file'
     installed = HAVE_NEO
     NeoRawIOClass = 'BlackrockRawIO'
+
+    def __init__(self, filename: PathType, block_index: Optional[float] = None, seg_index: Optional[float] = None):
+        super().__init__(filename=filename, block_index=block_index, seg_index=seg_index)
 
 
 class BlackrockSortingExtractor(NeoBaseSortingExtractor):

--- a/spikeextractors/extractors/neoextractors/neobaseextractor.py
+++ b/spikeextractors/extractors/neoextractors/neobaseextractor.py
@@ -48,9 +48,9 @@ class _NeoBaseExtractor:
 
 class NeoBaseRecordingExtractor(RecordingExtractor, _NeoBaseExtractor):
 
-    def __init__(self, **kargs):
+    def __init__(self, block_index=None, seg_index=None, **kargs):
         RecordingExtractor.__init__(self)
-        _NeoBaseExtractor.__init__(self, **kargs)
+        _NeoBaseExtractor.__init__(self, block_index=None, seg_index=None, **kargs)
 
         # TODO propose a meachanisim to select the appropriate channel groups
         # in neo one channel group have the same dtype/sampling_rate/group_id

--- a/spikeextractors/extractors/neoextractors/neobaseextractor.py
+++ b/spikeextractors/extractors/neoextractors/neobaseextractor.py
@@ -56,10 +56,10 @@ class NeoBaseRecordingExtractor(RecordingExtractor, _NeoBaseExtractor):
         # in neo one channel group have the same dtype/sampling_rate/group_id
         try:
             # Neo >= 0.9.0
-            channel_indexes_list = neorawio.get_group_signal_channel_indexes()
+            channel_indexes_list = self.neo_reader.get_group_signal_channel_indexes()
         except AttributeError:
             # Neo < 0.9.0
-            channel_indexes_list = neorawio.get_group_channel_indexes()        
+            channel_indexes_list = self.neo_reader.get_group_channel_indexes()        
         num_chan_group = len(channel_indexes_list)
         assert num_chan_group == 1, 'This file have several channel groups spikeextractors support only one groups'
 

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -30,8 +30,8 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
     ----------
     file_path : str
         Path to the .dat file to be extracted.
-    gain : float
-        Numerical value that converts the native int dtype to microvolts.
+    gain : float, optional
+        Numerical value that converts the native int dtype to microvolts. Defaults to 1.
     """
 
     extractor_name = "NeuroscopeRecordingExtractor"
@@ -40,7 +40,7 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
     mode = "file"
     installation_mesg = "Please install lxml to use this extractor!"
 
-    def __init__(self, file_path: PathType, gain: float):
+    def __init__(self, file_path: PathType, gain: float = 1.0):
         assert HAVE_LXML, self.installation_mesg
         file_path = Path(file_path)
         assert file_path.is_file() and file_path.suffix in [".dat", ".eeg"], \
@@ -70,7 +70,7 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
                                           dtype=dtype, numchan=numchan_from_file)
         self.set_channel_gains(channel_ids=list(range(numchan_from_file)), gains=gain)
 
-        self._kwargs = dict(file_path=str(Path(file_path).absolute()), gain=1)
+        self._kwargs = dict(file_path=str(Path(file_path).absolute()), gain=gain)
 
     @staticmethod
     def write_recording(recording: RecordingExtractor, save_path: PathType, dtype: DtypeType = None,
@@ -152,8 +152,8 @@ class NeuroscopeMultiRecordingTimeExtractor(MultiRecordingTimeExtractor):
     ----------
     folder_path : PathType
         Path to the .dat files to be extracted.
-    gain : float
-        Numerical value that converts the native int dtype to microvolts.
+    gain : float, optional
+        Numerical value that converts the native int dtype to microvolts. Defaults to 1.
     """
 
     extractor_name = "NeuroscopeMultiRecordingTimeExtractor"
@@ -162,7 +162,7 @@ class NeuroscopeMultiRecordingTimeExtractor(MultiRecordingTimeExtractor):
     mode = "folder"
     installation_mesg = "Please install lxml to use this extractor!"
 
-    def __init__(self, folder_path: PathType, gain: float):
+    def __init__(self, folder_path: PathType, gain: float = 1.0):
         assert HAVE_LXML, self.installation_mesg
 
         folder_path = Path(folder_path)

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -71,7 +71,7 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
                                           dtype=dtype, numchan=numchan_from_file)
 
         if gain is not None:
-            self.set_channel_gains(channel_ids=list(range(numchan_from_file)), gains=gain)
+            self.set_channel_gains(channel_ids=self.get_channel_ids(), gains=gain)
 
         self._kwargs = dict(file_path=str(Path(file_path).absolute()), gain=gain)
 

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -84,15 +84,10 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
 
         BinDatRecordingExtractor.__init__(self, file_path, sampling_frequency=sampling_frequency,
                                           dtype=dtype, numchan=numchan_from_file)
-
-<<<<<<< HEAD
-        self._kwargs = dict(file_path=str(Path(file_path).absolute()))
-=======
         if gain is not None:
             self.set_channel_gains(channel_ids=self.get_channel_ids(), gains=gain)
 
         self._kwargs = dict(file_path=str(Path(file_path).absolute()), gain=gain)
->>>>>>> master
 
     @staticmethod
     def write_recording(

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -85,14 +85,10 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
         BinDatRecordingExtractor.__init__(self, file_path, sampling_frequency=sampling_frequency,
                                           dtype=dtype, numchan=numchan_from_file)
 
-<<<<<<< HEAD
-        self._kwargs = dict(file_path=str(Path(file_path).absolute()))
-=======
         if gain is not None:
             self.set_channel_gains(channel_ids=self.get_channel_ids(), gains=gain)
 
         self._kwargs = dict(file_path=str(Path(file_path).absolute()), gain=gain)
->>>>>>> master
 
     @staticmethod
     def write_recording(

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -29,7 +29,7 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
     Parameters
     ----------
     file_path : str
-        Path to the .dat file to be extracted
+        Path to the .dat file to be extracted.
     gain : float
         Numerical value that converts the native int dtype to microvolts.
     """

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -70,7 +70,7 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
                                           dtype=dtype, numchan=numchan_from_file)
         self.set_channel_gains(channel_ids=list(range(numchan_from_file)), gains=gain)
 
-        self._kwargs = {'file_path': str(Path(file_path).absolute())}
+        self._kwargs = dict(file_path=str(Path(file_path).absolute()), gain=1)
 
     @staticmethod
     def write_recording(recording: RecordingExtractor, save_path: PathType, dtype: DtypeType = None,
@@ -152,6 +152,8 @@ class NeuroscopeMultiRecordingTimeExtractor(MultiRecordingTimeExtractor):
     ----------
     folder_path : PathType
         Path to the .dat files to be extracted.
+    gain : float
+        Numerical value that converts the native int dtype to microvolts.
     """
 
     extractor_name = "NeuroscopeMultiRecordingTimeExtractor"
@@ -160,17 +162,17 @@ class NeuroscopeMultiRecordingTimeExtractor(MultiRecordingTimeExtractor):
     mode = "folder"
     installation_mesg = "Please install lxml to use this extractor!"
 
-    def __init__(self, folder_path: PathType):
+    def __init__(self, folder_path: PathType, gain: float):
         assert HAVE_LXML, self.installation_mesg
 
         folder_path = Path(folder_path)
         recording_files = [x for x in folder_path.iterdir() if x.is_file() and x.suffix == ".dat"]
         assert any(recording_files), "The folder_path must lead to at least one .dat file!"
 
-        recordings = [NeuroscopeRecordingExtractor(file_path=x) for x in recording_files]
+        recordings = [NeuroscopeRecordingExtractor(file_path=x, gain=gain) for x in recording_files]
         MultiRecordingTimeExtractor.__init__(self, recordings=recordings)
 
-        self._kwargs = {'folder_path': str(folder_path.absolute())}
+        self._kwargs = dict(folder_path=str(folder_path.absolute()), gain=gain)
 
     @staticmethod
     def write_recording(recording: Union[MultiRecordingTimeExtractor, RecordingExtractor],

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -6,6 +6,7 @@ from spikeextractors.extraction_tools import check_valid_unit_id, get_sub_extrac
 from typing import Union
 import re
 import warnings
+from typing import Optional
 
 try:
     from lxml import etree as et
@@ -40,7 +41,7 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
     mode = "file"
     installation_mesg = "Please install lxml to use this extractor!"
 
-    def __init__(self, file_path: PathType, gain: float = 1.0):
+    def __init__(self, file_path: PathType, gain: Optional[float] = None):
         assert HAVE_LXML, self.installation_mesg
         file_path = Path(file_path)
         assert file_path.is_file() and file_path.suffix in [".dat", ".eeg"], \
@@ -68,7 +69,9 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
 
         BinDatRecordingExtractor.__init__(self, file_path, sampling_frequency=sampling_frequency,
                                           dtype=dtype, numchan=numchan_from_file)
-        self.set_channel_gains(channel_ids=list(range(numchan_from_file)), gains=gain)
+
+        if gain is not None:
+            self.set_channel_gains(channel_ids=list(range(numchan_from_file)), gains=gain)
 
         self._kwargs = dict(file_path=str(Path(file_path).absolute()), gain=gain)
 
@@ -162,7 +165,7 @@ class NeuroscopeMultiRecordingTimeExtractor(MultiRecordingTimeExtractor):
     mode = "folder"
     installation_mesg = "Please install lxml to use this extractor!"
 
-    def __init__(self, folder_path: PathType, gain: float = 1.0):
+    def __init__(self, folder_path: PathType, gain: Optional[float] = None):
         assert HAVE_LXML, self.installation_mesg
 
         folder_path = Path(folder_path)

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -30,15 +30,17 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
     ----------
     file_path : str
         Path to the .dat file to be extracted
+    gain : float
+        Numerical value that converts the native int dtype to microvolts.
     """
 
-    extractor_name = 'NeuroscopeRecordingExtractor'
+    extractor_name = "NeuroscopeRecordingExtractor"
     installed = HAVE_LXML
     is_writable = True
-    mode = 'file'
-    installation_mesg = 'Please install lxml to use this extractor!'  # error message when not installed
+    mode = "file"
+    installation_mesg = "Please install lxml to use this extractor!"
 
-    def __init__(self, file_path: PathType):
+    def __init__(self, file_path: PathType, gain: float):
         assert HAVE_LXML, self.installation_mesg
         file_path = Path(file_path)
         assert file_path.is_file() and file_path.suffix in [".dat", ".eeg"], \
@@ -49,9 +51,9 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
         file_path = Path(file_path)
         folder_path = file_path.parent
 
-        xml_files = [f for f in folder_path.iterdir() if f.is_file() if f.suffix == '.xml']
-        assert any(xml_files), 'No .xml file found in the folder_path.'
-        assert len(xml_files) == 1, 'More than one .xml file found in the folder_path.'
+        xml_files = [f for f in folder_path.iterdir() if f.is_file() if f.suffix == ".xml"]
+        assert any(xml_files), "No .xml file found in the folder_path."
+        assert len(xml_files) == 1, "More than one .xml file found in the folder_path."
         xml_filepath = xml_files[0]
 
         xml_root = et.parse(str(xml_filepath.absolute())).getroot()
@@ -66,6 +68,7 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
 
         BinDatRecordingExtractor.__init__(self, file_path, sampling_frequency=sampling_frequency,
                                           dtype=dtype, numchan=numchan_from_file)
+        self.set_channel_gains(channel_ids=list(range(numchan_from_file)), gains=gain)
 
         self._kwargs = {'file_path': str(Path(file_path).absolute())}
 

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -84,7 +84,6 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
 
         BinDatRecordingExtractor.__init__(self, file_path, sampling_frequency=sampling_frequency,
                                           dtype=dtype, numchan=numchan_from_file)
-
         if gain is not None:
             self.set_channel_gains(channel_ids=self.get_channel_ids(), gains=gain)
 
@@ -319,10 +318,6 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         Optional. Path to the collection of .res and .clu text files. Will auto-detect format.
     keep_mua_units : bool
         Optional. Whether or not to return sorted spikes from multi-unit activity. Defaults to True.
-    spkfile_path : PathType
-        Optional. Path to a particular .spk binary file containing waveform snippets added to the extractor as features.
-    gain : float
-        Optional. If passing a spkfile_path, this value converts the data type of the waveforms to units of microvolts.
     """
 
     extractor_name = "NeuroscopeSortingExtractor"
@@ -336,9 +331,7 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         resfile_path: OptionalPathType = None,
         clufile_path: OptionalPathType = None,
         folder_path: OptionalPathType = None,
-        keep_mua_units: bool = True,
-        spkfile_path: OptionalPathType = None,
-        gain: Optional[float] = None
+        keep_mua_units: bool = True
     ):
         assert HAVE_LXML, self.installation_mesg
         assert not (folder_path is None and resfile_path is None and clufile_path is None), \
@@ -417,43 +410,20 @@ class NeuroscopeSortingExtractor(SortingExtractor):
                 for s_id in self._unit_ids:
                     self._spiketrains.append(res[(clu == s_id + 1).nonzero()])  # from 2,...,clu[0]-1
 
-        if spkfile_path is not None and Path(spkfile_path).is_file():
-            n_bits = int(xml_root.find('acquisitionSystem').find('nBits').text)
-            dtype = f"int{n_bits}"
-            n_samples = int(xml_root.find('neuroscope').find('spikes').find('nSamples').text)
-            wf = np.memmap(spkfile_path, dtype=dtype)
-            n_channels = int(wf.size / (n_spikes * n_samples))
-            wf = wf.reshape(n_spikes, n_samples, n_channels)
-
-            for unit_id in self.get_unit_ids():
-                if gain is not None:
-                    self.set_unit_property(unit_id=unit_id, property_name='gain', value=gain)
-                self.set_unit_spike_features(
-                    unit_id=unit_id,
-                    feature_name='waveforms',
-                    value=wf[clu == unit_id + 1 - int(keep_mua_units), :, :]
-                )
-
         if folder_path_passed:
             self._kwargs = dict(
                 resfile_path=None,
                 clufile_path=None,
                 folder_path=str(folder_path.absolute()),
-                keep_mua_units=keep_mua_units,
-                gain=gain
+                keep_mua_units=keep_mua_units
             )
         else:
             self._kwargs = dict(
                 resfile_path=str(resfile_path.absolute()),
                 clufile_path=str(clufile_path.absolute()),
                 folder_path=None,
-                keep_mua_units=keep_mua_units,
-                gain=gain
+                keep_mua_units=keep_mua_units
             )
-        if spkfile_path is not None:
-            self._kwargs.update(spkfile_path=str(spkfile_path.absolute()))
-        else:
-            self._kwargs.update(spkfile_path=spkfile_path)
 
     def get_unit_ids(self):
         return list(self._unit_ids)
@@ -549,11 +519,6 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
     exclude_shanks : list
         Optional. List of indices to ignore. The set of all possible indices is chosen by default, extracted as the
         final integer of all the .res.%i and .clu.%i pairs.
-    write_waveforms : bool
-        Optional. If True, extracts waveform data from .spk.%i files in the path corresponding to
-        the .res.%i and .clue.%i files and sets these as unit spike features. Defaults to False.
-    gain : float
-        Optional. If passing a spkfile_path, this value converts the data type of the waveforms to units of microvolts.
     """
 
     extractor_name = "NeuroscopeMultiSortingExtractor"
@@ -566,9 +531,7 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
         self,
         folder_path: PathType,
         keep_mua_units: bool = True,
-        exclude_shanks: Optional[list] = None,
-        write_waveforms: bool = False,
-        gain: Optional[float] = None
+        exclude_shanks: Optional[list] = None
     ):
         assert HAVE_LXML, self.installation_mesg
 
@@ -609,27 +572,16 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
 
         all_shanks_list_se = []
         for shank_id in list(set(res_ids) - set(exclude_shanks)):
-            nse_args = dict(
-                resfile_path=folder_path / f"{sorting_name}.res.{shank_id}",
-                clufile_path=folder_path / f"{sorting_name}.clu.{shank_id}",
-                keep_mua_units=keep_mua_units
+            resfile_path = folder_path / f"{sorting_name}.res.{shank_id}"
+            clufile_path = folder_path / f"{sorting_name}.clu.{shank_id}"
+
+            all_shanks_list_se.append(
+                NeuroscopeSortingExtractor(
+                    resfile_path=resfile_path,
+                    clufile_path=clufile_path,
+                    keep_mua_units=keep_mua_units
+                )
             )
-
-            if write_waveforms:
-                spk_files = get_shank_files(folder_path=folder_path, suffix=".spk")
-                assert len(spk_files) > 0, "No .spk files found in the folder_path, but 'write_waveforms' is True!"
-                assert len(spk_files) == len(res_files), "Mismatched number of .spk and .res files!"
-
-                spk_ids = [int(x.suffix[1:]) for x in spk_files]
-                assert sorted(spk_ids) == sorted(res_ids), "Unmatched .spk.%i and .res.%i files detected!"
-
-                spkfile_names = [x.name[:x.name.find('.spk')] for x in spk_files]
-                assert np.all(s == r for (s, r) in zip(spkfile_names, resfile_names)), \
-                    "Some of the .spk.%i and .res.%i files do not share the same name!"
-
-                nse_args.update(spkfile_path=folder_path / f"{sorting_name}.spk.{shank_id}", gain=gain)
-
-            all_shanks_list_se.append(NeuroscopeSortingExtractor(**nse_args))
 
         MultiSortingExtractor.__init__(self, sortings=all_shanks_list_se)
 
@@ -637,17 +589,13 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
             self._kwargs = dict(
                 folder_path=str(folder_path.absolute()),
                 keep_mua_units=keep_mua_units,
-                exclude_shanks=exclude_shanks,
-                write_waveforms=write_waveforms,
-                gain=gain
+                exclude_shanks=exclude_shanks
             )
         else:
             self._kwargs = dict(
                 folder_path=str(folder_path.absolute()),
                 keep_mua_units=keep_mua_units,
-                exclude_shanks=None,
-                write_waveforms=write_waveforms,
-                gain=gain
+                exclude_shanks=None
             )
 
     @staticmethod

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -700,7 +700,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             scalar_conversion = 1.
             channel_conversion = gains * 1e-6
 
-        if isinstance(recording.get_traces(), np.memmap):
+        if isinstance(recording.get_traces(end_frame=5), np.memmap):
             n_bytes = np.dtype(recording.get_dtype()).itemsize
             buffer_size = int(buffer_mb * 1e6) // (recording.get_num_channels() * n_bytes)
             ephys_data = DataChunkIterator(
@@ -1133,7 +1133,8 @@ class NwbSortingExtractor(se.SortingExtractor):
                 property_shapes[pr] = shapes
 
             for pr in property_shapes.keys():
-                if not np.all([elem == property_shapes[pr][0] for elem in property_shapes[pr]]):
+                elems = [elem for elem in property_shapes[pr] if not np.isnan(elem)]
+                if not np.all([elem == elems[0] for elem in elems]):
                     print(f"Skipping property '{pr}' because it has variable size across units.")
                     skip_properties.append(pr)
 

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -33,6 +33,11 @@ def check_nwb_install():
     assert HAVE_NWB, "To use the Nwb extractors, install pynwb: \n\n pip install pynwb\n\n"
 
 
+def check_waveform_features(sorting: se.SortingExtractor, unit_id: int):
+    assert 'waveforms' in sorting.get_unit_spike_feature_names(unit_id=unit_id), \
+        "Attempting to write waveforms, but there are none set as features in the SortingExtractor!"
+
+
 def set_dynamic_table_property(dynamic_table, row_ids, property_name, values, index=False,
                                default_value=np.nan, table=False, description='no description'):
     check_nwb_install()
@@ -98,17 +103,18 @@ def get_nspikes(units_table, unit_id):
 
 def most_relevant_ch(traces):
     """
-    Calculates the most relevant channel for an Unit.
+    Calculate the most relevant channel for a unit.
+
     Estimates the channel where the max-min difference of the average traces is greatest.
     traces : ndarray
-        ndarray of shape (nSpikes, nChannels, nSamples)
+        ndarray of shape (nSpikes, nSamples, nChannels)
     """
-    n_channels = traces.shape[1]
+    n_channels = traces.shape[2]
     avg = np.mean(traces, axis=0)
 
     max_min = np.zeros(n_channels)
     for ch in range(n_channels):
-        max_min[ch] = avg[ch, :].max() - avg[ch, :].min()
+        max_min[ch] = avg[:, ch].max() - avg[:, ch].min()
 
     relevant_ch = np.argmax(max_min)
     return relevant_ch
@@ -1071,12 +1077,19 @@ class NwbSortingExtractor(se.SortingExtractor):
             property_descriptions: Optional[dict] = None,
             skip_properties: Optional[List[str]] = None,
             skip_features: Optional[List[str]] = None,
-            timestamps: Optional[ArrayType] = None
-        ):
+            timestamps: Optional[ArrayType] = None,
+            write_waveforms: bool = False,
+            write_waveform_stats: bool = False
+    ):
         """Auxilliary function for write_sorting."""
+        if skip_properties is None:
+            skip_properties = set(['gain'])
+        if skip_features is None:
+            skip_features = set(['waveforms'])
+
         unit_ids = sorting.get_unit_ids()
-        fs = sorting.get_sampling_frequency()
-        if fs is None:
+        sf = sorting.get_sampling_frequency()
+        if sf is None:
             raise ValueError("Writing a SortingExtractor to an NWBFile requires a known sampling frequency!")
 
         all_properties = set()
@@ -1098,16 +1111,6 @@ class NwbSortingExtractor(se.SortingExtractor):
             property_descriptions = dict(default_descriptions)
         else:
             property_descriptions = dict(default_descriptions, **property_descriptions)
-        for pr in all_properties:
-            if pr not in property_descriptions:
-                warnings.warn(
-                    f"Description for property {pr} not found in property_descriptions. "
-                    "Setting description to 'no description'"
-                )
-        if skip_properties is None:
-            skip_properties = []
-        if skip_features is None:
-            skip_features = []
 
         if nwbfile.units is None:
             # Check that array properties have the same shape across units
@@ -1126,7 +1129,7 @@ class NwbSortingExtractor(se.SortingExtractor):
                                 shapes.append(np.array(prop_value).shape)
                         elif isinstance(prop_value, dict):
                             print(f"Skipping property '{pr}' because dictionaries are not supported.")
-                            skip_properties.append(pr)
+                            skip_properties.update(pr)
                             break
                     else:
                         shapes.append(np.nan)
@@ -1135,54 +1138,73 @@ class NwbSortingExtractor(se.SortingExtractor):
             for pr in property_shapes.keys():
                 if not np.all([elem == property_shapes[pr][0] for elem in property_shapes[pr]]):
                     print(f"Skipping property '{pr}' because it has variable size across units.")
-                    skip_properties.append(pr)
+                    skip_properties.update(pr)
 
-            write_properties = set(all_properties) - set(skip_properties)
+            write_properties = all_properties - skip_properties
             for pr in write_properties:
+                if pr not in property_descriptions:
+                    warnings.warn(
+                        f"Description for property {pr} not found in property_descriptions. "
+                        "Setting description to 'no description'"
+                    )
                 unit_col_args = dict(name=pr, description=property_descriptions.get(pr, "No description."))
                 if pr in ['max_channel', 'max_electrode'] and nwbfile.electrodes is not None:
                     unit_col_args.update(table=nwbfile.electrodes)
                 nwbfile.add_unit_column(**unit_col_args)
 
             for unit_id in unit_ids:
-                unit_kwargs = dict()
-                # spike trains withinin the SortingExtractor object are not scaled by sampling frequency
+                unit_kwargs = dict(id=unit_id)
+
+                # spike trains withinin the SortingExtractor object are in units of sampling frames
                 if timestamps is not None:
                     spike_train_frames = sorting.get_unit_spike_train(unit_id=unit_id)
-                    assert spike_train_frames[-1] < len(timestamps), "Number of 'timestamps' differs from number of " \
-                                                                     "'frames'!"
-                    spkt = np.array(timestamps)[spike_train_frames]
+                    assert spike_train_frames[-1] < len(timestamps), \
+                        "Number of 'timestamps' differs from number of 'frames'!"
+                    unit_kwargs.update(spike_times=np.array(timestamps)[spike_train_frames])
                 else:
-                    spkt = sorting.get_unit_spike_train(unit_id=unit_id) / fs
+                    unit_kwargs.update(spike_times=sorting.get_unit_spike_train(unit_id=unit_id) / sf)
+
                 for pr in write_properties:
                     if pr in sorting.get_unit_property_names(unit_id):
                         prop_value = sorting.get_unit_property(unit_id, pr)
                         unit_kwargs.update({pr: prop_value})
                     else:  # Case of missing data for this unit and this property
                         unit_kwargs.update({pr: np.nan})
-                nwbfile.add_unit(id=unit_id, spike_times=spkt, **unit_kwargs)
 
-            # TODO
-            # # Stores average and std of spike traces
-            # This will soon be updated to the current NWB standard
-            # if 'waveforms' in sorting.get_unit_spike_feature_names(unit_id=id):
-            #     wf = sorting.get_unit_spike_features(unit_id=id,
-            #                                          feature_name='waveforms')
-            #     relevant_ch = most_relevant_ch(wf)
-            #     # Spike traces on the most relevant channel
-            #     traces = wf[:, relevant_ch, :]
-            #     traces_avg = np.mean(traces, axis=0)
-            #     traces_std = np.std(traces, axis=0)
-            #     nwbfile.add_unit(
-            #         id=id,
-            #         spike_times=spkt,
-            #         waveform_mean=traces_avg,
-            #         waveform_sd=traces_std
-            #     )
+                if write_waveforms:
+                    check_waveform_features(sorting=sorting, unit_id=unit_id)
+                    wf = sorting.get_unit_spike_features(unit_id=unit_id, feature_name='waveforms')
+                    unit_kwargs.update(waveforms=wf)
+
+                if write_waveform_stats:
+                    check_waveform_features(sorting=sorting, unit_id=unit_id)
+                    wf = sorting.get_unit_spike_features(unit_id=unit_id, feature_name='waveforms')
+                    relevant_ch = most_relevant_ch(wf)
+                    traces = wf[:, :, relevant_ch]
+                    traces_avg = np.mean(traces, axis=0)
+                    traces_std = np.std(traces, axis=0)
+                    unit_kwargs.update(waveform_mean=traces_avg, waveform_sd=traces_std)
+
+                nwbfile.add_unit(**unit_kwargs)
+
+            if write_waveforms:
+                nwbfile.units.waveform_rate = sf  # Hz
+
+                # channels gains - for RecordingExtractor, these are values to cast traces to uV
+                # for nwb, the conversions (gains) cast the data to Volts
+                gain = np.unique(np.squeeze([
+                    sorting.get_unit_property(unit_id=unit_id, property_name='gain')
+                    if 'gain' in sorting.get_unit_property_names(unit_id=unit_id) else 1
+                    for unit_id in unit_ids
+                ]))
+                if len(gain) > 1:
+                    raise NotImplementedError("Writing waveforms with channel conversion factors is not supported!")
+                nwbfile.units.waveform_conversion = gain[0] * 1e-6
 
             # Check that multidimensional features have the same shape across units
+            write_features = all_features - skip_features
             feature_shapes = dict()
-            for ft in all_features:
+            for ft in write_features:
                 shapes = []
                 for unit_id in unit_ids:
                     if ft in sorting.get_unit_spike_feature_names(unit_id):
@@ -1195,11 +1217,11 @@ class NwbSortingExtractor(se.SortingExtractor):
                                 feature_shapes[ft] = shapes
                         elif isinstance(feat_value[0], dict):
                             print(f"Skipping feature '{ft}' because dictionaries are not supported.")
-                            skip_features.append(ft)
+                            write_features -= set(ft)
                             break
                     else:
                         print(f"Skipping feature '{ft}' because not share across all units.")
-                        skip_features.append(ft)
+                        write_features -= set(ft)
                         break
 
             nspikes = {k: get_nspikes(nwbfile.units, int(k)) for k in unit_ids}
@@ -1208,16 +1230,16 @@ class NwbSortingExtractor(se.SortingExtractor):
                 # skip first dimension (num_spikes) when comparing feature shape
                 if not np.all([elem[1:] == feature_shapes[ft][0][1:] for elem in feature_shapes[ft]]):
                     print(f"Skipping feature '{ft}' because it has variable size across units.")
-                    skip_features.append(ft)
+                    write_features -= set(ft)
 
-            for ft in set(all_features) - set(skip_features):
+            for ft in write_features:
                 values = []
                 if not ft.endswith('_idxs'):
                     for unit_id in sorting.get_unit_ids():
                         feat_vals = sorting.get_unit_spike_features(unit_id, ft)
 
                         if len(feat_vals) < nspikes[unit_id]:
-                            skip_features.append(ft)
+                            write_features -= set(ft)
                             print(f"Skipping feature '{ft}' because it is not defined for all spikes.")
                             break
                             # this means features are available for a subset of spikes
@@ -1251,11 +1273,12 @@ class NwbSortingExtractor(se.SortingExtractor):
             skip_properties: Optional[List[str]] = None,
             skip_features: Optional[List[str]] = None,
             timestamps: ArrayType = None,
+            write_waveforms: bool = False,
+            write_waveform_stats: bool = False,
             **nwbfile_kwargs
         ):
         """
         Primary method for writing a SortingExtractor object to an NWBFile.
-
         Parameters
         ----------
         sorting: SortingExtractor
@@ -1270,21 +1293,28 @@ class NwbSortingExtractor(se.SortingExtractor):
                 my_recording_extractor, my_nwbfile
             )
             will result in the appropriate changes to the my_nwbfile object.
-        property_descriptions: dict
+        property_descriptions: dict (optional)
             For each key in this dictionary which matches the name of a unit
-            property in sorting, adds the value as a description to that
+                property in sorting, adds the value as a description to that
             custom unit column.
-        skip_properties: list of str
+        skip_properties: list of str (optional)
             Each string in this list that matches a unit property will not be written to the NWBFile.
-        skip_features: list of str
+        skip_features: list of str (optional)
             Each string in this list that matches a spike feature will not be written to the NWBFile.
-        timestamps: array-like
+        timestamps: array-like (optional)
             If provided, the timestamps in seconds or the assiciated RecordingExtractor to be saved as the unit
-            timestamps. (default=None)
-        nwbfile_kwargs: dict
+                timestamps.
+            Defaults to None.
+        write_waveforms: bool (optional)
+            If True, writes the waveform spike features to the units table in the NWBFile.
+            Defaults to False.
+        write_waveform_stats: bool (optional)
+            If True, calculates the mean and standard deviation of the waveform spike feature for the
+                most relevant channel and writes to the units table in the NWBFile.
+            Defaults to False.
+        nwbfile_kwargs: dict (optional)
             Information for constructing the nwb file (optional).
-            Only used if no nwbfile exists at the save_path, and no nwbfile
-            was directly passed.
+            Only used if no nwbfile exists at the save_path, and no nwbfile was directly passed.
         """
         assert HAVE_NWB, NwbSortingExtractor.installation_mesg
         assert save_path is None or nwbfile is None, \
@@ -1315,7 +1345,9 @@ class NwbSortingExtractor(se.SortingExtractor):
                     property_descriptions=property_descriptions,
                     skip_properties=skip_properties,
                     skip_features=skip_features,
-                    timestamps=timestamps
+                    timestamps=timestamps,
+                    write_waveforms=write_waveforms,
+                    write_waveform_stats=write_waveform_stats
                 )
                 io.write(nwbfile)
         else:
@@ -1325,5 +1357,7 @@ class NwbSortingExtractor(se.SortingExtractor):
                     property_descriptions=property_descriptions,
                     skip_properties=skip_properties,
                     skip_features=skip_features,
-                    timestamps=timestamps
+                    timestamps=timestamps,
+                    write_waveforms=write_waveforms,
+                    write_waveform_stats=write_waveform_stats
             )

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -1232,8 +1232,6 @@ class NwbSortingExtractor(se.SortingExtractor):
                     flatten_vals = [item for sublist in values for item in sublist]
                     nspks_list = [sp for sp in nspikes.values()]
                     spikes_index = np.cumsum(nspks_list).astype('int64')
-                    print(nwbfile.units)
-                    print(unit_ids)
                     set_dynamic_table_property(
                         dynamic_table=nwbfile.units,
                         row_ids=unit_ids,

--- a/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
@@ -90,7 +90,7 @@ class SpikeGLXRecordingExtractor(RecordingExtractor):
             gains = GainCorrectNI(self._timeseries, self._channels, meta)
 
         # set gains - convert from int16 to uVolt
-        self.set_channel_gains(self._channels, gains*1e6)
+        self.set_channel_gains(gains=gains*1e6, channel_ids=self._channels)
         self._kwargs = {'file_path': str(Path(file_path).absolute()), 'dtype': dtype}
 
     def get_channel_ids(self):

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -506,7 +506,7 @@ class TestExtractors(unittest.TestCase):
         nscope_dir = Path(self.test_dir) / 'neuroscope_rec0'
         dat_file = nscope_dir / 'neuroscope_rec0.dat'
         se.NeuroscopeRecordingExtractor.write_recording(self.RX, nscope_dir)
-        RX_ns = se.NeuroscopeRecordingExtractor(dat_file, gain=1)
+        RX_ns = se.NeuroscopeRecordingExtractor(dat_file)
 
         check_recording_return_types(RX_ns)
         check_recordings_equal(self.RX, RX_ns, force_dtype='int32')
@@ -521,7 +521,7 @@ class TestExtractors(unittest.TestCase):
         nscope_dir = Path(self.test_dir) / 'neuroscope_rec1'
         dat_file = nscope_dir / 'neuroscope_rec1.dat'
         se.NeuroscopeRecordingExtractor.write_recording(recording=self.RX, save_path=nscope_dir)
-        RX_ns = se.NeuroscopeRecordingExtractor(dat_file, gain=1)
+        RX_ns = se.NeuroscopeRecordingExtractor(dat_file)
         check_recording_return_types(RX_ns)
         check_recordings_equal(self.RX, RX_ns)
         check_dumping(RX_ns)
@@ -531,7 +531,7 @@ class TestExtractors(unittest.TestCase):
         dat_file = nscope_dir / "neuroscope_rec2.dat"
         RX_multirecording = se.MultiRecordingTimeExtractor(recordings=[self.RX, self.RX])
         se.NeuroscopeMultiRecordingTimeExtractor.write_recording(recording=RX_multirecording, save_path=nscope_dir)
-        RX_mre = se.NeuroscopeMultiRecordingTimeExtractor(folder_path=nscope_dir, gain=1)
+        RX_mre = se.NeuroscopeMultiRecordingTimeExtractor(folder_path=nscope_dir)
         check_recording_return_types(RX_mre)
         check_recordings_equal(RX_multirecording, RX_mre)
         check_dumping(RX_mre)

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -495,6 +495,7 @@ class TestExtractors(unittest.TestCase):
             skip_properties=['stability']
         )
         SX_nwb = se.NwbSortingExtractor(path1)
+        assert 'stability' not in SX_nwb.get_shared_unit_property_names()
         check_sortings_equal(self.SX, SX_nwb)
         check_dumping(SX_nwb)
 
@@ -506,6 +507,7 @@ class TestExtractors(unittest.TestCase):
             skip_features=['widths']
         )
         SX_nwb = se.NwbSortingExtractor(path1)
+        assert 'widths' not in SX_nwb.get_shared_unit_spike_feature_names()
         check_sortings_equal(self.SX2, SX_nwb)
         check_dumping(SX_nwb)
 

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -506,7 +506,7 @@ class TestExtractors(unittest.TestCase):
         nscope_dir = Path(self.test_dir) / 'neuroscope_rec0'
         dat_file = nscope_dir / 'neuroscope_rec0.dat'
         se.NeuroscopeRecordingExtractor.write_recording(self.RX, nscope_dir)
-        RX_ns = se.NeuroscopeRecordingExtractor(dat_file)
+        RX_ns = se.NeuroscopeRecordingExtractor(dat_file, gain=1)
 
         check_recording_return_types(RX_ns)
         check_recordings_equal(self.RX, RX_ns, force_dtype='int32')
@@ -521,7 +521,7 @@ class TestExtractors(unittest.TestCase):
         nscope_dir = Path(self.test_dir) / 'neuroscope_rec1'
         dat_file = nscope_dir / 'neuroscope_rec1.dat'
         se.NeuroscopeRecordingExtractor.write_recording(recording=self.RX, save_path=nscope_dir)
-        RX_ns = se.NeuroscopeRecordingExtractor(dat_file)
+        RX_ns = se.NeuroscopeRecordingExtractor(dat_file, gain=1)
         check_recording_return_types(RX_ns)
         check_recordings_equal(self.RX, RX_ns)
         check_dumping(RX_ns)
@@ -531,7 +531,7 @@ class TestExtractors(unittest.TestCase):
         dat_file = nscope_dir / "neuroscope_rec2.dat"
         RX_multirecording = se.MultiRecordingTimeExtractor(recordings=[self.RX, self.RX])
         se.NeuroscopeMultiRecordingTimeExtractor.write_recording(recording=RX_multirecording, save_path=nscope_dir)
-        RX_mre = se.NeuroscopeMultiRecordingTimeExtractor(folder_path=nscope_dir)
+        RX_mre = se.NeuroscopeMultiRecordingTimeExtractor(folder_path=nscope_dir, gain=1)
         check_recording_return_types(RX_mre)
         check_recordings_equal(RX_multirecording, RX_mre)
         check_dumping(RX_mre)


### PR DESCRIPTION
@alejoe91 @bendichter Allows unit spike features named 'waveforms' to be written to the units table as jagged columns.

Depends on branch `add_waveforms_cn` of the [CatalystNeuro fork of pynwb](https://github.com/catalystneuro/pynwb/tree/add_waveforms_cn).